### PR TITLE
Add CommandProcessor tests and refactor

### DIFF
--- a/src/main/java/com/example/geektrust/CommandProcessor.java
+++ b/src/main/java/com/example/geektrust/CommandProcessor.java
@@ -16,9 +16,6 @@ public class CommandProcessor {
     private String direction = DEFAULT_DIRECTION;
     private final PathFindingStrategy pathFinder;
 
-    private static final int ERROR_FILE_NOT_FOUND = 2;
-    private static final int ERROR_IO = 3;
-    private static final int ERROR_UNEXPECTED = 4;
 
     private static final int SOURCE_ARGS_COUNT = 4;
     private static final int DEST_ARGS_COUNT = 3;
@@ -32,18 +29,18 @@ public class CommandProcessor {
         this.pathFinder = pathFinder;
     }
 
-    public void run(String inputFile) {
+    public void run(String inputFile) throws IOException {
         try {
             processInputFile(inputFile);
         } catch (FileNotFoundException e) {
             System.err.println("Error: Input file not found: " + inputFile);
-            System.exit(ERROR_FILE_NOT_FOUND);
+            throw e;
         } catch (IOException e) {
             System.err.println("Error reading input file: " + e.getMessage());
-            System.exit(ERROR_IO);
+            throw e;
         } catch (Exception e) {
             System.err.println("An unexpected error occurred: " + e.getMessage());
-            System.exit(ERROR_UNEXPECTED);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/example/geektrust/Main.java
+++ b/src/main/java/com/example/geektrust/Main.java
@@ -2,6 +2,9 @@ package com.example.geektrust;
 
 public class Main {
     private static final int ERROR_NO_INPUT = 1;
+    private static final int ERROR_FILE_NOT_FOUND = 2;
+    private static final int ERROR_IO = 3;
+    private static final int ERROR_UNEXPECTED = 4;
 
     public static void main(String[] args) {
         if (args.length == 0) {
@@ -10,6 +13,14 @@ public class Main {
             System.exit(ERROR_NO_INPUT);
         }
 
-        new CommandProcessor().run(args[0]);
+        try {
+            new CommandProcessor().run(args[0]);
+        } catch (java.io.FileNotFoundException e) {
+            System.exit(ERROR_FILE_NOT_FOUND);
+        } catch (java.io.IOException e) {
+            System.exit(ERROR_IO);
+        } catch (RuntimeException e) {
+            System.exit(ERROR_UNEXPECTED);
+        }
     }
 }

--- a/src/test/java/com/example/geektrust/CommandProcessorTest.java
+++ b/src/test/java/com/example/geektrust/CommandProcessorTest.java
@@ -1,0 +1,76 @@
+package com.example.geektrust;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CommandProcessorTest {
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+    private ByteArrayOutputStream outContent;
+    private ByteArrayOutputStream errContent;
+
+    @BeforeEach
+    void setUpStreams() {
+        outContent = new ByteArrayOutputStream();
+        errContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @AfterEach
+    void restoreStreams() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    private File createTempInput(String content) throws Exception {
+        File temp = File.createTempFile("input", ".txt");
+        try (FileWriter writer = new FileWriter(temp)) {
+            writer.write(content);
+        }
+        return temp;
+    }
+
+    private static class StubPathFinder implements PathFindingStrategy {
+        private final int power;
+        StubPathFinder(int power) {
+            this.power = power;
+        }
+        @Override
+        public int calculatePower(Position source, Position destination, String direction) {
+            return power;
+        }
+    }
+
+    @Test
+    public void testRunWithValidCommands() throws Exception {
+        File input = createTempInput("SOURCE 0 0 N\nDESTINATION 1 0\nPRINT_POWER\n");
+        CommandProcessor cp = new CommandProcessor(new StubPathFinder(123));
+        assertDoesNotThrow(() -> cp.run(input.getAbsolutePath()));
+        assertTrue(outContent.toString().contains("POWER 123"));
+    }
+
+    @Test
+    public void testInvalidCoordinateShowsError() throws Exception {
+        File input = createTempInput("SOURCE 7 0 N\nPRINT_POWER\n");
+        CommandProcessor cp = new CommandProcessor(new StubPathFinder(0));
+        cp.run(input.getAbsolutePath());
+        assertTrue(errContent.toString().contains("coordinate"));
+    }
+
+    @Test
+    public void testUnknownCommandWarns() throws Exception {
+        File input = createTempInput("JUMP 1 1\n");
+        CommandProcessor cp = new CommandProcessor(new StubPathFinder(0));
+        cp.run(input.getAbsolutePath());
+        assertTrue(errContent.toString().contains("Unknown command"));
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `CommandProcessor.run` to throw exceptions instead of exiting
- propagate exit codes in `Main`
- add `CommandProcessorTest` covering successful execution, error output and unknown commands
- remove unused exit code constants from `CommandProcessor`
- replace magic numbers in `Main` with named constants

## Testing
- `mvn -q test` *(fails: plugin resolution network error)*

------
https://chatgpt.com/codex/tasks/task_e_68639691f3708321bc7350e6afb13db8