### PR TITLE
Add Maven workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,19 @@
+name: Maven Build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          # Temurin is the stable Eclipse Adoptium build of OpenJDK
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Build with Maven
+        run: mvn -B clean install


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `mvn clean install` on pull requests using Java 8
- clarify that Temurin distribution is used for stability

## Testing
- `mvn -B clean install` *(fails: Network is unreachable)*
- `mvn --version`


------
https://chatgpt.com/codex/tasks/task_e_68639b0123dc8321baf819c212841991