### PR TITLE
Centralize error handling via ApplicationError enum

### DIFF
--- a/src/main/java/com/example/geektrust/ApplicationError.java
+++ b/src/main/java/com/example/geektrust/ApplicationError.java
@@ -1,0 +1,18 @@
+package com.example.geektrust;
+
+public enum ApplicationError {
+    NO_INPUT(1),
+    FILE_NOT_FOUND(2),
+    IO_ERROR(3),
+    UNEXPECTED_ERROR(4);
+
+    private final int exitCode;
+
+    ApplicationError(int exitCode) {
+        this.exitCode = exitCode;
+    }
+
+    public int getExitCode() {
+        return exitCode;
+    }
+}

--- a/src/main/java/com/example/geektrust/Main.java
+++ b/src/main/java/com/example/geektrust/Main.java
@@ -2,27 +2,18 @@ package com.example.geektrust;
 
 import com.example.geektrust.command.CommandProcessor;
 
+/**
+ * Entry point of the application.
+ */
 public class Main {
-    private static final int ERROR_NO_INPUT = 1;
-    private static final int ERROR_FILE_NOT_FOUND = 2;
-    private static final int ERROR_IO = 3;
-    private static final int ERROR_UNEXPECTED = 4;
 
     public static void main(String[] args) {
         if (args.length == 0) {
             System.err.println("Error: No input file provided.");
             System.err.println("Usage: java -jar <jar-file> <input-file>");
-            System.exit(ERROR_NO_INPUT);
+            System.exit(ApplicationError.NO_INPUT.getExitCode());
         }
 
-        try {
-            new CommandProcessor().run(args[0]);
-        } catch (java.io.FileNotFoundException e) {
-            System.exit(ERROR_FILE_NOT_FOUND);
-        } catch (java.io.IOException e) {
-            System.exit(ERROR_IO);
-        } catch (RuntimeException e) {
-            System.exit(ERROR_UNEXPECTED);
-        }
+        new CommandProcessor().run(args[0]);
     }
 }

--- a/src/main/java/com/example/geektrust/command/CommandProcessor.java
+++ b/src/main/java/com/example/geektrust/command/CommandProcessor.java
@@ -1,5 +1,6 @@
 package com.example.geektrust.command;
 
+import com.example.geektrust.ApplicationError;
 import com.example.geektrust.service.PathFindingStrategy;
 import com.example.geektrust.service.PowerCalculator;
 
@@ -20,18 +21,18 @@ public class CommandProcessor {
         this.context = new CommandContext(pathFinder);
     }
 
-    public void run(String inputFile) throws IOException {
+    public void run(String inputFile) {
         try {
             processInputFile(inputFile);
         } catch (FileNotFoundException e) {
             System.err.println("Error: Input file not found: " + inputFile);
-            throw e;
+            System.exit(ApplicationError.FILE_NOT_FOUND.getExitCode());
         } catch (IOException e) {
             System.err.println("Error reading input file: " + e.getMessage());
-            throw e;
-        } catch (Exception e) {
+            System.exit(ApplicationError.IO_ERROR.getExitCode());
+        } catch (RuntimeException e) {
             System.err.println("An unexpected error occurred: " + e.getMessage());
-            throw new RuntimeException(e);
+            System.exit(ApplicationError.UNEXPECTED_ERROR.getExitCode());
         }
     }
 

--- a/src/test/java/com/example/geektrust/MainEntryTest.java
+++ b/src/test/java/com/example/geektrust/MainEntryTest.java
@@ -1,6 +1,8 @@
 package com.example.geektrust;
 
 import org.junit.jupiter.api.Test;
+
+import com.example.geektrust.ApplicationError;
 import java.io.File;
 import java.io.FileWriter;
 import static org.junit.jupiter.api.Assertions.*;
@@ -24,7 +26,7 @@ public class MainEntryTest {
         System.setSecurityManager(sm);
         try {
             assertThrows(SecurityException.class, () -> Main.main(new String[]{}));
-            assertEquals(1, sm.status);
+            assertEquals(ApplicationError.NO_INPUT.getExitCode(), sm.status);
         } finally {
             System.setSecurityManager(original);
         }
@@ -37,7 +39,7 @@ public class MainEntryTest {
         System.setSecurityManager(sm);
         try {
             assertThrows(SecurityException.class, () -> Main.main(new String[]{"nofile.txt"}));
-            assertEquals(2, sm.status);
+            assertEquals(ApplicationError.FILE_NOT_FOUND.getExitCode(), sm.status);
         } finally {
             System.setSecurityManager(original);
         }


### PR DESCRIPTION
## Summary
- define `ApplicationError` enum for exit codes
- simplify `Main` by removing try-catch blocks and using the enum
- handle all error exits inside `CommandProcessor.run`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6863afcd48d88321a26a19dd1da56a53