### PR TITLE
Refactor path finders to remove comments

### DIFF
--- a/src/main/java/com/example/geektrust/path/AStarPathFinder.java
+++ b/src/main/java/com/example/geektrust/path/AStarPathFinder.java
@@ -5,11 +5,11 @@ import com.example.geektrust.model.Direction;
 import com.example.geektrust.model.Position;
 import com.example.geektrust.model.State;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.PriorityQueue;
 
-/**
- * A* path finder for extensible use cases.
- */
+
 public class AStarPathFinder extends AbstractPathFinder {
 
     public AStarPathFinder(Board board, int moveCost, int turnCost) {
@@ -29,17 +29,9 @@ public class AStarPathFinder extends AbstractPathFinder {
 
     @Override
     public int findMinPower(Position source, Position dest, Direction startDir) {
-        int size = board.getSize();
-        int dirCount = Direction.values().length;
-        int[][][] gScore = new int[size][size][dirCount];
-        for (int[][] arr2d : gScore) {
-            for (int[] arr1d : arr2d) {
-                Arrays.fill(arr1d, Integer.MAX_VALUE);
-            }
-        }
+        int[][][] gScore = newCostArray();
         PriorityQueue<State> open = new PriorityQueue<>(Comparator.comparingInt(s -> s.getPowerSpent()));
-        open.add(new State(source, startDir, 0));
-        gScore[source.getX()][source.getY()][startDir.ordinal()] = 0;
+        enqueueStart(source, startDir, gScore, open);
         int best = Integer.MAX_VALUE;
 
         while (!open.isEmpty()) {
@@ -51,11 +43,8 @@ public class AStarPathFinder extends AbstractPathFinder {
             if (cur.getPowerSpent() >= best) {
                 continue;
             }
-            // move forward
             moveForward(cur, gScore, open, dest);
-            // turn left
             turnLeft(cur, gScore, open, dest);
-            // turn right
             turnRight(cur, gScore, open, dest);
         }
         return best;

--- a/src/main/java/com/example/geektrust/path/AbstractPathFinder.java
+++ b/src/main/java/com/example/geektrust/path/AbstractPathFinder.java
@@ -5,11 +5,10 @@ import com.example.geektrust.model.Direction;
 import com.example.geektrust.model.Position;
 import com.example.geektrust.model.State;
 
+import java.util.Arrays;
 import java.util.Queue;
 
-/**
- * Provides common movement operations for path finders.
- */
+
 public abstract class AbstractPathFinder implements PathFinder {
     protected final Board board;
     protected final int moveCost;
@@ -21,12 +20,29 @@ public abstract class AbstractPathFinder implements PathFinder {
         this.turnCost = turnCost;
     }
 
-    /**
-     * Determine the priority with which a state should be queued.
-     * By default this is the cost spent so far.
-     */
+
     protected int computePriority(Position pos, int costSoFar, Position dest) {
         return costSoFar;
+    }
+
+
+    protected int[][][] newCostArray() {
+        int size = board.getSize();
+        int dirCount = Direction.values().length;
+        int[][][] costs = new int[size][size][dirCount];
+        for (int[][] arr2d : costs) {
+            for (int[] arr1d : arr2d) {
+                Arrays.fill(arr1d, Integer.MAX_VALUE);
+            }
+        }
+        return costs;
+    }
+
+
+    protected void enqueueStart(Position source, Direction startDir,
+                                int[][][] costs, Queue<State> q) {
+        q.add(new State(source, startDir, 0));
+        costs[source.getX()][source.getY()][startDir.ordinal()] = 0;
     }
 
     protected void moveForward(State cur, int[][][] costs, Queue<State> q, Position dest) {

--- a/src/main/java/com/example/geektrust/path/BFSPathFinder.java
+++ b/src/main/java/com/example/geektrust/path/BFSPathFinder.java
@@ -5,15 +5,10 @@ import com.example.geektrust.model.Direction;
 import com.example.geektrust.model.Position;
 import com.example.geektrust.model.State;
 
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Queue;
 
-/**
- * Simple breadth-first search over (x,y,direction) states.
- * Costs are multiples of 5 so the queue processes states in
- * increasing cost units.
- */
+
 public class BFSPathFinder extends AbstractPathFinder {
 
     public BFSPathFinder(Board board, int moveCost, int turnCost) {
@@ -22,17 +17,9 @@ public class BFSPathFinder extends AbstractPathFinder {
 
     @Override
     public int findMinPower(Position source, Position dest, Direction startDir) {
-        int size = board.getSize();
-        int dirCount = Direction.values().length;
-        int[][][] minCost = new int[size][size][dirCount];
-        for (int[][] arr2d : minCost) {
-            for (int[] arr1d : arr2d) {
-                Arrays.fill(arr1d, Integer.MAX_VALUE);
-            }
-        }
+        int[][][] minCost = newCostArray();
         Queue<State> q = new LinkedList<>();
-        q.add(new State(source, startDir, 0));
-        minCost[source.getX()][source.getY()][startDir.ordinal()] = 0;
+        enqueueStart(source, startDir, minCost, q);
         int best = Integer.MAX_VALUE;
 
         while (!q.isEmpty()) {
@@ -44,11 +31,8 @@ public class BFSPathFinder extends AbstractPathFinder {
             if (cur.getPowerSpent() >= best) {
                 continue;
             }
-            // move forward
             moveForward(cur, minCost, q, dest);
-            // turn left
             turnLeft(cur, minCost, q, dest);
-            // turn right
             turnRight(cur, minCost, q, dest);
         }
         return best;

--- a/src/main/java/com/example/geektrust/path/DijkstraPathFinder.java
+++ b/src/main/java/com/example/geektrust/path/DijkstraPathFinder.java
@@ -5,13 +5,10 @@ import com.example.geektrust.model.Direction;
 import com.example.geektrust.model.Position;
 import com.example.geektrust.model.State;
 
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.PriorityQueue;
 
-/**
- * Classic Dijkstra search over (x,y,direction) states.
- */
+
 public class DijkstraPathFinder extends AbstractPathFinder {
 
     public DijkstraPathFinder(Board board, int moveCost, int turnCost) {
@@ -20,17 +17,9 @@ public class DijkstraPathFinder extends AbstractPathFinder {
 
     @Override
     public int findMinPower(Position source, Position dest, Direction startDir) {
-        int size = board.getSize();
-        int dirCount = Direction.values().length;
-        int[][][] minCost = new int[size][size][dirCount];
-        for (int[][] arr2d : minCost) {
-            for (int[] arr1d : arr2d) {
-                Arrays.fill(arr1d, Integer.MAX_VALUE);
-            }
-        }
+        int[][][] minCost = newCostArray();
         PriorityQueue<State> pq = new PriorityQueue<>(Comparator.comparingInt(State::getPowerSpent));
-        pq.add(new State(source, startDir, 0));
-        minCost[source.getX()][source.getY()][startDir.ordinal()] = 0;
+        enqueueStart(source, startDir, minCost, pq);
         int best = Integer.MAX_VALUE;
 
         while (!pq.isEmpty()) {
@@ -42,11 +31,8 @@ public class DijkstraPathFinder extends AbstractPathFinder {
                 best = Math.min(best, cur.getPowerSpent());
                 continue;
             }
-            // move forward
             moveForward(cur, minCost, pq, dest);
-            // turn left
             turnLeft(cur, minCost, pq, dest);
-            // turn right
             turnRight(cur, minCost, pq, dest);
         }
         return best;


### PR DESCRIPTION
## Summary
- remove Javadoc and inline comments from AbstractPathFinder
- remove comments from BFS, Dijkstra and A* implementations

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c7248cf48321a5f655cbaf650b93